### PR TITLE
add postgres data source to grafana

### DIFF
--- a/services/grafana/datasource.yml
+++ b/services/grafana/datasource.yml
@@ -13,3 +13,16 @@ datasources:
   isDefault: true
   access: proxy
   editable: true
+- name: Postgres
+  type: postgres
+  url: postgres:5432
+  user: postgres
+  secureJsonData:
+    password: 'postgres'
+  jsonData:
+    database: WeScore
+    sslmode: 'disable' # disable/require/verify-ca/verify-full
+    maxOpenConns: 100 # Grafana v5.4+
+    maxIdleConns: 100 # Grafana v5.4+
+    maxIdleConnsAuto: true # Grafana v9.5.1+
+    connMaxLifetime: 14400 # Grafana v5.4+


### PR DESCRIPTION
Create a dummy table `comments` and it shows up in the grafana UI

<img width="1622" alt="Screenshot 2023-11-05 at 5 33 24 PM" src="https://github.com/RMathews/WeScore/assets/6857498/c624ce7f-c548-46c7-8589-0647a6f3000c">
